### PR TITLE
🩹 사파리(safari) 브라우저 flex height 상속 버그

### DIFF
--- a/front/components/Store/StyleStoreCard.js
+++ b/front/components/Store/StyleStoreCard.js
@@ -19,6 +19,7 @@ export const CardImageBlock = styled.div`
 `;
 export const CardImageItem = styled.img`
   display: inline-block;
+  height: 75%;
 `;
 
 export const CardMeta = styled.div`


### PR DESCRIPTION
이미지 자식요소에 height 값 명시